### PR TITLE
fix: add prepare script for GitHub installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
+    "prepare": "tsc",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- Add `prepare` script to package.json that runs `tsc` after npm install
- When installing via `npm install github:coco-xyz/botshub-sdk`, dist/ is not in git (.gitignore). The prepare script builds it automatically.

## Test plan
- [ ] `npm install github:coco-xyz/botshub-sdk` succeeds and dist/ is built