### PR TITLE
feat: immediate reconnect on close code 1012

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -117,6 +117,8 @@ export class BotsHubClient {
   // E1: Auto-reconnect state
   private readonly reconnectOpts: Required<ReconnectOptions>;
   private reconnectAttempts = 0;
+  private immediateReconnects = 0;
+  private readonly maxImmediateReconnects = 3;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private intentionalDisconnect = false;
 
@@ -201,6 +203,7 @@ export class BotsHubClient {
 
     this.intentionalDisconnect = false;
     this.reconnectAttempts = 0;
+    this.immediateReconnects = 0;
     this.clearReconnectTimer();
 
     await this.doConnect();
@@ -243,14 +246,21 @@ export class BotsHubClient {
       return;
     }
 
-    // On 1012 (Service Restart), reconnect immediately with no backoff and reset attempts
-    const delay = immediate ? 0 : Math.min(
+    // Cap consecutive immediate reconnects to prevent storm on repeated 1012
+    const doImmediate = immediate && this.immediateReconnects < this.maxImmediateReconnects;
+
+    const delay = doImmediate ? 0 : Math.min(
       this.reconnectOpts.initialDelay * Math.pow(this.reconnectOpts.backoffFactor, this.reconnectAttempts),
       this.reconnectOpts.maxDelay,
     );
-    if (!immediate) this.reconnectAttempts++;
+    if (doImmediate) {
+      this.immediateReconnects++;
+    } else {
+      this.reconnectAttempts++;
+      this.immediateReconnects = 0;
+    }
 
-    this.emit('reconnecting', { attempt: this.reconnectAttempts, delay });
+    this.emit('reconnecting', { attempt: this.reconnectAttempts || this.immediateReconnects, delay });
 
     this.reconnectTimer = setTimeout(async () => {
       if (this.intentionalDisconnect) return;
@@ -263,8 +273,9 @@ export class BotsHubClient {
         }
         // NOTE: Messages received during disconnect are not auto-replayed.
         // Consumers should listen for 'reconnected' and call getCatchupEvents() to recover missed messages.
-        this.emit('reconnected', { attempts: this.reconnectAttempts });
+        this.emit('reconnected', { attempts: this.reconnectAttempts || this.immediateReconnects });
         this.reconnectAttempts = 0;
+        this.immediateReconnects = 0;
       } catch {
         this.scheduleReconnect();
       }


### PR DESCRIPTION
## Summary

- Capture WebSocket close code from close event
- On close code 1012 (Service Restart): reconnect immediately with zero delay, don't increment backoff counter
- On other close codes: use normal exponential backoff (unchanged behavior)

## Why

Pairs with bots-hub server-side SIGQUIT handler (coco-xyz/bots-hub#38). When nginx reloads, the server sends 1012 to all clients. SDK clients should reconnect instantly rather than waiting through backoff delays, ensuring seamless service continuity.

## Test plan

- [x] TypeScript compiles clean
- [ ] Manual test: server sends 1012 → client reconnects with 0ms delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)