### PR TITLE
feat: org auth support (Phase 6)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -421,7 +421,6 @@ export class BotsHubClient {
     name: string,
     opts?: {
       display_name?: string;
-      role?: 'admin' | 'member';
       bio?: string;
       [key: string]: unknown;
     },
@@ -847,8 +846,8 @@ export class BotsHubClient {
   /**
    * Change an agent's auth role (admin only).
    */
-  setAgentRole(agentId: string, role: 'admin' | 'member'): Promise<{ ok: boolean }> {
-    return this.patch<{ ok: boolean }>(`/api/org/agents/${agentId}/role`, { role });
+  setAgentRole(agentId: string, role: 'admin' | 'member'): Promise<{ agent_id: string; auth_role: string }> {
+    return this.patch<{ agent_id: string; auth_role: string }>(`/api/org/agents/${agentId}/role`, { auth_role: role });
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,22 +213,23 @@ export interface CatchupCountResponse {
 
 export interface OrgTicket {
   ticket: string;
-  expires_in: number;
+  expires_at: number;
   reusable: boolean;
 }
 
 export interface LoginResponse {
   ticket: string;
-  expires_in: number;
+  expires_at: number;
   reusable: boolean;
-  org: { org_id: string; name: string };
+  org: { id: string; name: string };
 }
 
 export interface RegisterResponse {
   agent_id: string;
   org_id: string;
-  token: string;
-  role: string;
+  name: string;
+  token?: string;
+  auth_role: string;
 }
 
 export interface OrgInfo {


### PR DESCRIPTION
## Summary
- Add `orgId` option to `BotsHubClientOptions` — auto-injects `X-Org-Id` header on all requests and WS connections
- Static methods: `BotsHubClient.login(baseUrl, orgId, orgSecret)` and `BotsHubClient.register(baseUrl, ticket)` for pre-connection auth
- Instance admin methods: `createOrgTicket()`, `rotateOrgSecret()`, `setAgentRole()`, `getOrgInfo()`
- New types: `OrgTicket`, `LoginResponse`, `RegisterResponse`, `OrgInfo`
- Fully backward compatible — existing clients work without changes

## Context
Phase 6 of the Org Auth Redesign. Depends on bots-hub PRs #41-45 (server-side Phases 1-5).

## Test plan
- [ ] Verify TypeScript compiles cleanly
- [ ] Test login → register → connect flow with org auth enabled server
- [ ] Verify backward compatibility: client without orgId still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)