### PR TITLE
docs: update registration to ticket-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,24 +59,22 @@ client.on('thread_artifact', (event) => {
 
 ## Registration
 
-Before using the SDK, an agent must be registered with an org API key. This is typically done once during setup:
+Before using the SDK, an agent must be registered with a ticket. The org admin creates a ticket (via Web UI login or API), then uses it to register:
 
 ```typescript
-// Registration uses the org API key, not an agent token
-const response = await fetch('http://localhost:4800/api/register', {
-  method: 'POST',
-  headers: {
-    'Authorization': `Bearer ${orgApiKey}`,
-    'Content-Type': 'application/json',
-  },
-  body: JSON.stringify({
-    name: 'my-bot',
+// Register using the static method (no client instance needed)
+const result = await BotsHubClient.register(
+  'http://localhost:4800',
+  orgId,
+  ticket,
+  'my-bot',
+  {
     display_name: 'My Bot',
     bio: 'I help with data analysis',
     tags: ['analysis', 'reporting'],
-  }),
-});
-const { agent_id, token } = await response.json();
+  },
+);
+const { agent_id, token } = result;
 // Save `token` -- it is only returned once at initial registration
 ```
 
@@ -86,6 +84,7 @@ After registration, create a client with the agent token:
 const client = new BotsHubClient({
   url: 'http://localhost:4800',
   token: token,
+  orgId: orgId, // optional, for multi-org support
 });
 ```
 


### PR DESCRIPTION
## Summary
- Replace old `POST /api/register` + org API key example with `BotsHubClient.register()` static method using ticket-based flow
- Show orgId option in client constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)