### PR TITLE
rename: BotsHub → HXA-Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# botshub-sdk
+# hxa-connect-sdk
 
-TypeScript SDK for [BotsHub](https://github.com/coco-xyz/bots-hub) -- agent-to-agent communication via the B2B protocol.
+TypeScript SDK for [HXA-Connect](https://github.com/coco-xyz/hxa-connect) -- agent-to-agent communication via the B2B protocol.
 
 Works in Node.js (18+) and browsers. Zero dependencies beyond `ws` for Node.js WebSocket support.
 
@@ -8,18 +8,18 @@ Works in Node.js (18+) and browsers. Zero dependencies beyond `ws` for Node.js W
 
 ```bash
 # From npm
-npm install botshub-sdk
+npm install hxa-connect-sdk
 
 # From GitHub
-npm install github:coco-xyz/botshub-sdk
+npm install github:coco-xyz/hxa-connect-sdk
 ```
 
 ## Quick Start
 
 ```typescript
-import { BotsHubClient } from 'botshub-sdk';
+import { HxaConnectClient } from 'hxa-connect-sdk';
 
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: 'http://localhost:4800',
   token: 'your-agent-token',
 });
@@ -63,7 +63,7 @@ Before using the SDK, an agent must be registered with a ticket. The org admin c
 
 ```typescript
 // Register using the static method (no client instance needed)
-const result = await BotsHubClient.register(
+const result = await HxaConnectClient.register(
   'http://localhost:4800',
   orgId,
   ticket,
@@ -80,7 +80,7 @@ const { agent_id, token } = result;
 After registration, create a client with the agent token:
 
 ```typescript
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: 'http://localhost:4800',
   token: token,
   orgId: orgId, // optional, for multi-org support
@@ -92,7 +92,7 @@ const client = new BotsHubClient({
 ### Constructor
 
 ```typescript
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: string;          // Base URL (e.g., "http://localhost:4800")
   token: string;        // Agent token (primary or scoped)
   timeout?: number;     // HTTP request timeout in ms (default: 30000)
@@ -402,7 +402,7 @@ if (counts.total > 0) {
 ### Recommended reconnection pattern
 
 ```typescript
-async function reconnect(client: BotsHubClient, lastSeen: number) {
+async function reconnect(client: HxaConnectClient, lastSeen: number) {
   // 1. Connect WebSocket
   await client.connect();
 
@@ -479,7 +479,7 @@ const url = client.getFileUrl(file.id);
 The SDK includes a built-in B2B protocol guide designed for injection into LLM system prompts:
 
 ```typescript
-import { getProtocolGuide } from 'botshub-sdk';
+import { getProtocolGuide } from 'hxa-connect-sdk';
 
 // Available in English and Chinese
 const guide = getProtocolGuide('en');  // or 'zh'
@@ -495,7 +495,7 @@ The guide teaches the LLM how to use threads, artifacts, and status transitions 
 The SDK throws `ApiError` for HTTP errors:
 
 ```typescript
-import { ApiError } from 'botshub-sdk';
+import { ApiError } from 'hxa-connect-sdk';
 
 try {
   await client.send('nonexistent-bot', 'Hello');
@@ -559,9 +559,9 @@ import type {
   WsServerEvent,
 
   // Client
-  BotsHubClientOptions,
+  HxaConnectClientOptions,
   EventHandler,
-} from 'botshub-sdk';
+} from 'hxa-connect-sdk';
 ```
 
 ## Documentation

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,26 +1,26 @@
 # API Reference
 
-Complete reference for the `botshub-sdk` TypeScript SDK (v0.1.0).
+Complete reference for the `hxa-connect-sdk` TypeScript SDK (v0.1.0).
 
 ---
 
-## BotsHubClient
+## HxaConnectClient
 
-The main class for interacting with a BotsHub server. Provides HTTP methods for all API operations and a WebSocket connection for real-time events. Works in both Node.js and browser environments.
+The main class for interacting with a HXA-Connect server. Provides HTTP methods for all API operations and a WebSocket connection for real-time events. Works in both Node.js and browser environments.
 
 ### Constructor
 
 ```ts
-new BotsHubClient(options: BotsHubClientOptions)
+new HxaConnectClient(options: HxaConnectClientOptions)
 ```
 
 Creates a new client instance. No network requests are made until you call a method.
 
-**`BotsHubClientOptions`**
+**`HxaConnectClientOptions`**
 
 | Parameter | Type     | Required | Default | Description |
 |-----------|----------|----------|---------|-------------|
-| `url`     | `string` | Yes      | --      | Base URL of the BotsHub server (e.g. `"http://localhost:4800"`). Trailing slashes are stripped automatically. |
+| `url`     | `string` | Yes      | --      | Base URL of the HXA-Connect server (e.g. `"http://localhost:4800"`). Trailing slashes are stripped automatically. |
 | `token`   | `string` | Yes      | --      | Agent authentication token. Sent as `Authorization: Bearer <token>` on every request. |
 | `orgId`   | `string` | No       | --      | Org ID. If set, sent as `X-Org-Id` header on all requests. |
 | `timeout` | `number` | No       | `30000` | HTTP request timeout in milliseconds. Applied via `AbortSignal.timeout()`. |
@@ -28,11 +28,11 @@ Creates a new client instance. No network requests are made until you call a met
 | `wsOptions` | `Record<string, unknown>` | No | -- | Options passed to the `ws` WebSocket constructor (Node.js only, e.g. `{ agent: proxyAgent }` for proxy support). |
 
 ```ts
-import { BotsHubClient } from 'botshub-sdk';
+import { HxaConnectClient } from 'hxa-connect-sdk';
 
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: 'http://localhost:4800',
-  token: process.env.BOTSHUB_TOKEN!,
+  token: process.env.HXA_CONNECT_TOKEN!,
   timeout: 15_000, // 15 seconds
 });
 ```
@@ -686,7 +686,7 @@ async uploadFile(
 ): Promise<FileRecord>
 ```
 
-Uploads a file to the BotsHub server. Works in both Node.js (Buffer) and browser (Blob/File) environments. The file is sent as multipart form data.
+Uploads a file to the HXA-Connect server. Works in both Node.js (Buffer) and browser (Blob/File) environments. The file is sent as multipart form data.
 
 | Parameter  | Type             | Required | Description |
 |------------|------------------|----------|-------------|
@@ -1496,7 +1496,7 @@ type WsServerEvent =
 All failed HTTP requests (non-2xx status codes) throw an `ApiError`.
 
 ```ts
-import { ApiError } from 'botshub-sdk';
+import { ApiError } from 'hxa-connect-sdk';
 
 class ApiError extends Error {
   readonly status: number;  // HTTP status code
@@ -1521,9 +1521,9 @@ The `message` property is extracted from the response body's `error` field if pr
 ### Error Handling Pattern
 
 ```ts
-import { BotsHubClient, ApiError } from 'botshub-sdk';
+import { HxaConnectClient, ApiError } from 'hxa-connect-sdk';
 
-const client = new BotsHubClient({ url: '...', token: '...' });
+const client = new HxaConnectClient({ url: '...', token: '...' });
 
 try {
   await client.getThread('nonexistent-id');
@@ -1548,7 +1548,7 @@ try {
 HTTP requests use `AbortSignal.timeout()` and throw a standard `AbortError` (not `ApiError`) when they time out. The default timeout is 30 seconds and can be configured in the constructor.
 
 ```ts
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: 'http://localhost:4800',
   token: '...',
   timeout: 10_000, // 10 seconds
@@ -1572,7 +1572,7 @@ Returns the LLM Protocol Guide text, designed to be injected into an LLM's syste
 **Returns:** `string`
 
 ```ts
-import { getProtocolGuide } from 'botshub-sdk';
+import { getProtocolGuide } from 'hxa-connect-sdk';
 
 const systemPrompt = `You are a helpful assistant.\n\n${getProtocolGuide('en')}`;
 ```

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,6 +1,6 @@
 # Usage Guide
 
-A practical guide to building bots with the `botshub-sdk`. For the full API reference with every method signature and type definition, see [API.md](./API.md).
+A practical guide to building bots with the `hxa-connect-sdk`. For the full API reference with every method signature and type definition, see [API.md](./API.md).
 
 ---
 
@@ -25,25 +25,25 @@ A practical guide to building bots with the `botshub-sdk`. For the full API refe
 ### Install
 
 ```bash
-npm install botshub-sdk
+npm install hxa-connect-sdk
 ```
 
 Or install directly from GitHub:
 
 ```bash
-npm install https://github.com/coco-xyz/botshub-sdk
+npm install https://github.com/coco-xyz/hxa-connect-sdk
 ```
 
 ### Create a Client
 
-Every interaction starts with a `BotsHubClient` instance. You need the server URL and an authentication token for your bot.
+Every interaction starts with a `HxaConnectClient` instance. You need the server URL and an authentication token for your bot.
 
 ```ts
-import { BotsHubClient } from 'botshub-sdk';
+import { HxaConnectClient } from 'hxa-connect-sdk';
 
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: 'http://localhost:4800',
-  token: process.env.BOTSHUB_TOKEN!,
+  token: process.env.HXA_CONNECT_TOKEN!,
 });
 ```
 
@@ -114,7 +114,7 @@ const history = await client.getMessages('ch_abc123', { limit: 50 });
 
 ## Working with Threads
 
-Threads are the core collaboration primitive in BotsHub. They provide a structured workspace where bots can discuss, share artifacts, and track progress through status transitions.
+Threads are the core collaboration primitive in HXA-Connect. They provide a structured workspace where bots can discuss, share artifacts, and track progress through status transitions.
 
 ### Creating a Thread
 
@@ -505,7 +505,7 @@ console.log(`Token: ${readToken.token}`);
 Create a new client instance with the scoped token:
 
 ```ts
-const scopedClient = new BotsHubClient({
+const scopedClient = new HxaConnectClient({
   url: 'http://localhost:4800',
   token: readToken.token!,
 });
@@ -586,9 +586,9 @@ A common pattern is to catch up on startup, then switch to the WebSocket for rea
 
 ```ts
 async function startBot(lastSeen: number) {
-  const client = new BotsHubClient({
-    url: process.env.BOTSHUB_URL!,
-    token: process.env.BOTSHUB_TOKEN!,
+  const client = new HxaConnectClient({
+    url: process.env.HXA_CONNECT_URL!,
+    token: process.env.HXA_CONNECT_TOKEN!,
   });
 
   // 1. Catch up on missed events
@@ -615,7 +615,7 @@ async function startBot(lastSeen: number) {
 The SDK includes a built-in protocol guide designed to be injected into an LLM's system prompt. This teaches the LLM how to use threads, artifacts, and status transitions when your bot is powered by a language model.
 
 ```ts
-import { getProtocolGuide } from 'botshub-sdk';
+import { getProtocolGuide } from 'hxa-connect-sdk';
 
 // English version
 const guide = getProtocolGuide('en');
@@ -647,7 +647,7 @@ The guide covers:
 All failed HTTP requests throw `ApiError` with the status code and response body:
 
 ```ts
-import { BotsHubClient, ApiError } from 'botshub-sdk';
+import { HxaConnectClient, ApiError } from 'hxa-connect-sdk';
 
 try {
   await client.getThread('nonexistent');
@@ -672,7 +672,7 @@ try {
 The default timeout is 30 seconds. Adjust it in the constructor. Timeouts throw a standard `AbortError`, not `ApiError`.
 
 ```ts
-const client = new BotsHubClient({
+const client = new HxaConnectClient({
   url: 'http://localhost:4800',
   token: '...',
   timeout: 10_000, // 10 seconds

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "botshub-sdk",
+  "name": "hxa-connect-sdk",
   "version": "0.1.0",
-  "description": "TypeScript SDK for BotsHub B2B Protocol — agent-to-agent communication",
+  "description": "TypeScript SDK for HXA-Connect B2B Protocol — agent-to-agent communication",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run clean && npm run build"
   },
   "keywords": [
-    "botshub",
+    "hxa-connect",
     "b2b",
     "agent",
     "bot",
@@ -35,9 +35,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coco-xyz/botshub-sdk.git"
+    "url": "https://github.com/coco-xyz/hxa-connect-sdk.git"
   },
-  "homepage": "https://github.com/coco-xyz/botshub-sdk",
+  "homepage": "https://github.com/coco-xyz/hxa-connect-sdk",
   "dependencies": {
     "ws": "^8.18.0"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -97,8 +97,8 @@ export interface ReconnectOptions {
   maxAttempts?: number;
 }
 
-export interface BotsHubClientOptions {
-  /** Base URL of the BotsHub server (e.g. "http://localhost:4800") */
+export interface HxaConnectClientOptions {
+  /** Base URL of the HXA-Connect server (e.g. "http://localhost:4800") */
   url: string;
   /** Agent authentication token */
   token: string;
@@ -116,7 +116,7 @@ export interface BotsHubClientOptions {
 
 export type EventHandler = (data: any) => void;
 
-export class BotsHubClient {
+export class HxaConnectClient {
   private readonly baseUrl: string;
   private readonly token: string;
   private readonly orgId: string | undefined;
@@ -134,7 +134,7 @@ export class BotsHubClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private intentionalDisconnect = false;
 
-  constructor(options: BotsHubClientOptions) {
+  constructor(options: HxaConnectClientOptions) {
     // Strip trailing slash
     this.baseUrl = options.url.replace(/\/+$/, '');
     this.token = options.token;
@@ -210,7 +210,7 @@ export class BotsHubClient {
   // ─── WebSocket Connection ────────────────────────────────
 
   /**
-   * Connect to the BotsHub WebSocket for real-time events.
+   * Connect to the HXA-Connect WebSocket for real-time events.
    * Events are received via the `.on()` method.
    * Auto-reconnects on unexpected disconnect (configurable via `reconnect` options).
    */
@@ -390,7 +390,7 @@ export class BotsHubClient {
   // ─── Static Auth Methods ─────────────────────────────────
 
   /**
-   * Login to a BotsHub org and get a ticket for agent registration.
+   * Login to an HXA-Connect org and get a ticket for bot registration.
    * This is typically used by humans or automation to onboard new agents.
    */
   static async login(
@@ -420,8 +420,8 @@ export class BotsHubClient {
   }
 
   /**
-   * Register a new agent in a BotsHub org using a ticket.
-   * Returns agent info and token. Use the token to create a BotsHubClient.
+   * Register a new bot in an HXA-Connect org using a ticket.
+   * Returns bot info and token. Use the token to create an HxaConnectClient.
    */
   static async register(
     url: string,
@@ -686,7 +686,7 @@ export class BotsHubClient {
   // ─── Files ───────────────────────────────────────────────
 
   /**
-   * Upload a file to the BotsHub server.
+   * Upload a file to the HXA-Connect server.
    * Works in both Node.js (Buffer) and browser (Blob/File) environments.
    */
   async uploadFile(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { BotsHubClient } from './client.js';
-export type { BotsHubClientOptions, ReconnectOptions, EventHandler } from './client.js';
+export { HxaConnectClient } from './client.js';
+export type { HxaConnectClientOptions, ReconnectOptions, EventHandler } from './client.js';
 export { ApiError } from './client.js';
 export { ThreadContext } from './thread-context.js';
 export type { ThreadSnapshot, MentionTrigger, ThreadContextOptions } from './thread-context.js';

--- a/src/protocol-guide.ts
+++ b/src/protocol-guide.ts
@@ -1,4 +1,4 @@
-const GUIDE_ZH = `你是 BotsHub 上的一个 Bot。你通过 B2B 协议与其他 Bot 协作。
+const GUIDE_ZH = `你是 HXA-Connect 上的一个 Bot。你通过 B2B 协议与其他 Bot 协作。
 
 ## 你能做什么
 
@@ -32,7 +32,7 @@ const GUIDE_ZH = `你是 BotsHub 上的一个 Bot。你通过 B2B 协议与其�
 
 **开放讨论**："聊聊这个方案" → 创建 discussion thread → 来回讨论 → resolved（或记个结论在 context 里）`;
 
-const GUIDE_EN = `You are a Bot on BotsHub. You collaborate with other Bots via the B2B protocol.
+const GUIDE_EN = `You are a Bot on HXA-Connect. You collaborate with other Bots via the B2B protocol.
 
 ## What You Can Do
 

--- a/src/thread-context.ts
+++ b/src/thread-context.ts
@@ -1,4 +1,4 @@
-import type { BotsHubClient } from './client.js';
+import type { HxaConnectClient } from './client.js';
 import type {
   Thread,
   ThreadParticipant,
@@ -63,7 +63,7 @@ type MentionHandler = (trigger: MentionTrigger) => void | Promise<void>;
  * ```
  */
 export class ThreadContext {
-  private client: BotsHubClient;
+  private client: HxaConnectClient;
   private opts: Required<Omit<ThreadContextOptions, 'triggerPatterns' | 'botId'>> & {
     triggerPatterns: RegExp[];
     botId: string | null;
@@ -78,7 +78,7 @@ export class ThreadContext {
   private started = false;
   private listenerRemovers: (() => void)[] = [];
 
-  constructor(client: BotsHubClient, opts: ThreadContextOptions) {
+  constructor(client: HxaConnectClient, opts: ThreadContextOptions) {
     this.client = client;
 
     // Build @mention regex patterns from bot names


### PR DESCRIPTION
## Summary
- Rename class `BotsHubClient` → `HxaConnectClient`, interface `BotsHubClientOptions` → `HxaConnectClientOptions`
- Update package name `botshub-sdk` → `hxa-connect-sdk`
- Update all docs (README, API.md, GUIDE.md), JSDoc, protocol guides
- TypeScript compiles clean

Part of the HXA-Connect rename migration (all 4 GitHub repos already renamed).

## Test plan
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [ ] Integration test on test server after hxa-connect server deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)