### PR TITLE
feat: add rename() method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -785,6 +785,13 @@ export class HxaConnectClient {
   }
 
   /**
+   * Rename the current bot.
+   */
+  rename(newName: string): Promise<Agent> {
+    return this.patch<Agent>('/api/me/name', { name: newName });
+  }
+
+  /**
    * List other bots in the same organization.
    */
   listPeers(): Promise<Agent[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -253,7 +253,7 @@ export interface OrgSettings {
 // ─── Audit Log ──────────────────────────────────────────────
 
 export type AuditAction =
-  | 'bot.register' | 'bot.delete' | 'bot.profile_update'
+  | 'bot.register' | 'bot.delete' | 'bot.profile_update' | 'bot.rename'
   | 'bot.token_create' | 'bot.token_revoke'
   | 'thread.create' | 'thread.status_changed' | 'thread.invite' | 'thread.remove_participant'
   | 'thread.permission_denied'
@@ -298,5 +298,6 @@ export type WsServerEvent =
   | { type: 'thread_message'; thread_id: string; message: WireThreadMessage }
   | { type: 'thread_artifact'; thread_id: string; artifact: Artifact; action: 'added' | 'updated' }
   | { type: 'thread_participant'; thread_id: string; bot_id: string; bot_name: string; action: 'joined' | 'left'; by: string; label?: string | null }
+  | { type: 'bot_renamed'; bot_id: string; old_name: string; new_name: string }
   | { type: 'error'; message: string; code?: string; retry_after?: number }
   | { type: 'pong' };


### PR DESCRIPTION
## Summary

- Add `rename(newName)` method to `HxaConnectClient` in the Profile section, enabling bots to change their display name via `PATCH /api/me/name`
- Add `'bot.rename'` to the `AuditAction` type union for audit log coverage
- Add `bot_renamed` event to `WsServerEvent` so connected clients receive real-time rename notifications

## Test plan

- [ ] Verify `client.rename('NewName')` sends `PATCH /api/me/name` with `{ name: 'NewName' }` and returns the updated `Agent`
- [ ] Confirm `bot_renamed` WebSocket events are correctly typed and dispatched to `.on('bot_renamed')` handlers
- [ ] Verify TypeScript compilation passes with no type errors