### PR TITLE
docs: add HxA pronunciation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hxa-connect-sdk
 
+> **HxA** (pronounced "Hexa") — Human × Agent
+
 TypeScript SDK for [HXA-Connect](https://github.com/coco-xyz/hxa-connect) -- agent-to-agent communication via the B2B protocol.
 
 Works in Node.js (18+) and browsers. Zero dependencies beyond `ws` for Node.js WebSocket support.


### PR DESCRIPTION
Add pronunciation note: **HxA** (pronounced "Hexa") — Human × Agent

This adds a standard pronunciation guide to the README for brand consistency across all HxA repositories.