### PR TITLE
fix: remove npm install command from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ Works in Node.js (18+) and browsers. Zero dependencies beyond `ws` for Node.js W
 ## Installation
 
 ```bash
-# From npm
-npm install hxa-connect-sdk
-
-# From GitHub
 npm install github:coco-xyz/hxa-connect-sdk
 ```
 


### PR DESCRIPTION
## Summary
- Remove `npm install hxa-connect-sdk` from README — package not yet published to npm
- Keep only the GitHub install command: `npm install github:coco-xyz/hxa-connect-sdk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)