### PR TITLE
chore: rename package to @coco-xyz/hxa-connect-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hxa-connect-sdk",
+  "name": "@coco-xyz/hxa-connect-sdk",
   "version": "1.1.0",
   "description": "TypeScript SDK for HXA-Connect B2B Protocol — agent-to-agent communication",
   "type": "module",


### PR DESCRIPTION
## Summary
- Rename package from `hxa-connect-sdk` to `@coco-xyz/hxa-connect-sdk` for npm publishing
- Required before `npm publish --access public`

## Next steps after merge
1. Tag v1.1.0
2. Create GitHub release
3. `npm publish --access public`

🤖 Generated with [Claude Code](https://claude.com/claude-code)