### PR TITLE
chore: v1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.1] - 2026-03-02
+
+### Fixed
+- Removed `'group'` from `Channel.type` union — channels are now exclusively `'direct'` (group channels removed from server)
+
 ## [1.1.0] - 2026-03-01
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete reference for the `hxa-connect-sdk` TypeScript SDK (v1.1.0).
+Complete reference for the `hxa-connect-sdk` TypeScript SDK (v1.1.1).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coco-xyz/hxa-connect-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "TypeScript SDK for HXA-Connect B2B Protocol — agent-to-agent communication",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version 1.1.0 → 1.1.1
- Update CHANGELOG with v1.1.1 entry (removed group channel type)
- Update API.md version reference

Follows merged PR #19 (remove `'group'` from `Channel.type`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)