### PR TITLE
fix: human provenance support in ThreadContext

### DIFF
--- a/src/thread-context.ts
+++ b/src/thread-context.ts
@@ -8,6 +8,31 @@ import type {
   ThreadStatus,
 } from './types.js';
 
+// ─── Helpers ─────────────────────────────────────────────────
+
+/** Parse metadata from string or object form. */
+function parseMeta(metadata: string | object | null | undefined): Record<string, unknown> | null {
+  if (!metadata) return null;
+  if (typeof metadata === 'string') {
+    try { return JSON.parse(metadata); } catch { return null; }
+  }
+  return metadata as Record<string, unknown>;
+}
+
+/**
+ * Build a display-friendly sender name.
+ * For human-authored messages (Web UI), shows "owner_name (via bot_name)".
+ */
+function displaySender(msg: WireThreadMessage): string {
+  const botName = msg.sender_name ?? msg.sender_id ?? 'system';
+  const meta = parseMeta(msg.metadata);
+  const prov = meta?.provenance as Record<string, unknown> | undefined;
+  if (prov?.authored_by === 'human' && prov.owner_name) {
+    return `${prov.owner_name} (via ${botName})`;
+  }
+  return botName;
+}
+
 // ─── Types ──────────────────────────────────────────────────
 
 export interface ThreadSnapshot {
@@ -178,8 +203,13 @@ export class ThreadContext {
   private handleThreadMessage(threadId: string, message: WireThreadMessage): void {
     if (!this.started) return;
 
-    // Don't buffer our own messages
-    if (message.sender_id === this.opts.botId) return;
+    // Don't buffer our own messages — but allow human-authored messages
+    // sent via Web UI (provenance.authored_by === 'human')
+    if (message.sender_id === this.opts.botId) {
+      const meta = parseMeta(message.metadata);
+      const prov = meta?.provenance as Record<string, unknown> | undefined;
+      if (!prov || prov.authored_by !== 'human') return;
+    }
 
     // Buffer the message
     const buffer = this.buffers.get(threadId) ?? [];
@@ -383,7 +413,7 @@ export class ThreadContext {
       lines.push('');
       lines.push(mode === 'delta' ? '### New Messages' : '### Messages');
       for (const msg of messages) {
-        const sender = msg.sender_name ?? msg.sender_id ?? 'system';
+        const sender = displaySender(msg);
         const time = new Date(msg.created_at).toISOString().slice(11, 19);
         lines.push(`[${time}] ${sender}: ${msg.content}`);
       }


### PR DESCRIPTION
## Summary
- **Self-message filter**: ThreadContext was dropping messages where `sender_id === botId`, including human-authored messages sent via Web UI (which uses the bot's token). Now checks `metadata.provenance.authored_by`: if `'human'`, the message is buffered normally.
- **Display sender**: `toPromptContext()` now shows human-authored messages as `owner_name (via bot_name)` instead of just the bot name.
- Adds shared `parseMeta()` and `displaySender()` helpers.

## Test plan
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Deployed locally, Web UI human messages now reach bot and display correct sender name
- [ ] Verify bot's own programmatic messages are still filtered (no echo loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)