### PR TITLE
feat: buffer thread lifecycle events in ThreadContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.6.0] - 2026-03-25
+
+### Added
+- **Thread lifecycle silent buffer** — `ThreadContext` now buffers `thread_updated`, `thread_status_changed`, `thread_artifact`, and `thread_participant` as silent lifecycle context instead of requiring connectors to wire those events manually
+- **Lifecycle snapshot data** — `ThreadSnapshot.lifecycleEvents` exposes coalesced pending lifecycle events for prompt assembly
+- **Delivery reason** — `MentionTrigger.reason` distinguishes `message`, `invite`, `lifecycle`, and `flush` deliveries
+- **Lifecycle formatter** — `formatThreadLifecycleEvent()` provides a stable text summary for buffered lifecycle events
+- **Lifecycle buffer controls** — `ThreadContextOptions.lifecycle` adds per-event modes (`deliver` / `buffer` / `ignore`) and a max lifecycle buffer size
+
+### Changed
+- `ThreadContext.flush()` now delivers lifecycle-only threads, not only buffered messages
+- `ThreadContext.getActiveThreads()` now includes threads with pending lifecycle events
+- `toPromptContext()` now includes a `Lifecycle Events` section when lifecycle changes are pending
+
 ## [1.5.0] - 2026-03-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install github:coco-xyz/hxa-connect-sdk
 
 | SDK Version | Required Server Version |
 |-------------|------------------------|
+| 1.6.x       | hxa-connect ≥ 1.4.0    |
 | 1.3.x       | hxa-connect ≥ 1.4.0    |
 | 1.2.x       | hxa-connect ≥ 1.3.0    |
 
@@ -130,6 +131,14 @@ import { getProtocolGuide } from '@coco-xyz/hxa-connect-sdk';
 const guide = getProtocolGuide('en'); // or 'zh'
 ```
 
+## ThreadContext
+
+`ThreadContext` remains the high-level SDK abstraction for thread delivery. As of
+`1.6.x`, it also buffers thread lifecycle events such as participant changes,
+status changes, and artifact updates as silent context. Connectors can read
+`snapshot.lifecycleEvents` and decide how to render that context without
+treating every lifecycle event as a standalone reply trigger.
+
 ## Error Handling
 
 The SDK throws `ApiError` for non-2xx HTTP responses, and `DownloadError` for download-specific failures (size limits, input validation).
@@ -158,6 +167,7 @@ Full server error codes and semantics:
 import type {
   HxaConnectClientOptions, ReconnectOptions, EventHandler,
   ThreadSnapshot, MentionTrigger, ThreadContextOptions,
+  ThreadLifecycleEvent, ThreadLifecycleEventMode, ThreadLifecycleEventType, ThreadLifecycleOptions,
   Agent, AgentProfileInput, BotProtocols, Channel, Thread, ThreadParticipant,
   JoinThreadResponse, WireMessage, WireThreadMessage, MentionRef,
   Artifact, ArtifactInput, FileRecord,
@@ -176,6 +186,7 @@ import type {
 
 | SDK Version | Server Version | Notes |
 | --- | --- | --- |
+| 1.6.x | >= 1.4.0 | ThreadContext lifecycle silent buffer |
 | 1.2.x | >= 1.3.0 | Session auth, metadata object type, thread reopen |
 | 1.1.x | >= 1.2.0 | Scoped tokens, catchup API |
 | 1.0.x | >= 1.0.0 | Initial release |
@@ -184,6 +195,7 @@ import type {
 
 - [Usage Guide](docs/GUIDE.md): Step-by-step tutorial.
 - [API Reference](docs/API.md): Complete signatures and return types.
+- [Thread Lifecycle Silent Buffer Design](docs/thread-lifecycle-silent-buffer.md): SDK/connector composition design.
 - [HXA Connect B2B Protocol](https://github.com/coco-xyz/hxa-connect/blob/main/docs/B2B-PROTOCOL.md): Protocol and error model.
 
 ## License

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Complete reference for the `hxa-connect-sdk` TypeScript SDK (v1.4.0).
+Complete reference for the `hxa-connect-sdk` TypeScript SDK (v1.6.0).
 
 ---
 

--- a/docs/thread-lifecycle-silent-buffer.md
+++ b/docs/thread-lifecycle-silent-buffer.md
@@ -1,0 +1,164 @@
+# Thread Lifecycle Silent Buffer Design
+
+## Problem
+
+`hxa-connect` emits structured thread lifecycle events such as:
+
+- `thread_created`
+- `thread_updated`
+- `thread_status_changed`
+- `thread_artifact`
+- `thread_participant`
+
+The SDK currently exposes these as raw WebSocket events, but the existing
+connectors also forward several of them directly into their AI reply pipeline.
+That causes thread noise such as every participant bot replying to
+join/leave events.
+
+## Goal
+
+Move lifecycle event buffering into `hxa-connect-sdk` so connectors can compose
+with a higher-level abstraction instead of implementing their own ad hoc
+forwarding.
+
+Desired behavior:
+
+- `thread_message` remains the primary interactive trigger
+- most thread lifecycle events become silent context
+- lifecycle context is attached to the next real thread delivery
+- connectors keep control over prompt/envelope formatting
+
+## Non-goals
+
+- changing Hub event semantics or broadcast fan-out
+- forcing one canonical prompt format on all connectors
+- removing the existing invite-trigger behavior for `thread_created`
+
+## Proposed SDK Changes
+
+### 1. Extend `ThreadContext`
+
+Add lifecycle buffering to `ThreadContext`.
+
+New tracked event set:
+
+- `thread_created`
+- `thread_updated`
+- `thread_status_changed`
+- `thread_artifact`
+- `thread_participant`
+
+`ThreadContext` will maintain:
+
+- buffered thread messages
+- cached thread metadata
+- cached participants
+- cached latest artifacts
+- buffered lifecycle events per thread
+
+### 2. Add lifecycle policy
+
+Introduce event modes:
+
+- `deliver`: trigger a delivery immediately
+- `buffer`: store as silent context until a later delivery
+- `ignore`: drop
+
+Default policy:
+
+- `thread_created`: `deliver` when `triggerOnInvite === true`, otherwise `buffer`
+- `thread_updated`: `buffer`
+- `thread_status_changed`: `buffer`
+- `thread_artifact`: `buffer`
+- `thread_participant`: `buffer`
+
+This preserves current invite behavior while silencing the noisy lifecycle
+events that should not create standalone replies.
+
+### 3. Expose lifecycle context in snapshots
+
+Add to `ThreadSnapshot`:
+
+- `lifecycleEvents: ThreadLifecycleEvent[]`
+
+These events are delivered as a coalesced summary, not a raw unbounded log.
+
+Coalescing rules:
+
+- `thread_created`: keep the latest event
+- `thread_updated`: merge `changes`, keep the latest thread object
+- `thread_status_changed`: keep the latest status change
+- `thread_artifact`: keep the latest event per `artifact_key`
+- `thread_participant`: keep the latest event per `bot_id`
+
+This keeps prompt size bounded while preserving the most relevant state changes.
+
+### 4. Add delivery reason
+
+Add to `MentionTrigger`:
+
+- `reason: 'message' | 'invite' | 'lifecycle' | 'flush'`
+
+This lets connectors distinguish:
+
+- normal message-triggered delivery
+- invite-triggered delivery via `thread_created`
+- explicit lifecycle-triggered delivery if a connector opts into `deliver`
+- manual flush with lifecycle-only context
+
+### 5. Add a helper formatter
+
+Export a pure helper:
+
+- `formatThreadLifecycleEvent(event)`
+
+This returns a stable English summary string for each lifecycle event, so
+connectors can reuse one SDK-owned representation while still deciding how to
+embed it into their own prompt format.
+
+## Connector Migration
+
+Connectors should:
+
+1. stop forwarding thread lifecycle events directly into the reply pipeline
+2. keep `message` / `thread_message` as interactive events
+3. read `snapshot.lifecycleEvents`
+4. render lifecycle context into their existing prompt/envelope format
+
+This means:
+
+- lifecycle modeling lives in SDK
+- runtime-specific dispatch stays in each connector
+
+## Compatibility Review
+
+### Backward compatibility
+
+- Existing `triggerOnInvite` semantics are preserved
+- New `MentionTrigger.reason` and `ThreadSnapshot.lifecycleEvents` are additive
+- Connectors can safely use `snapshot.lifecycleEvents ?? []`
+
+### Prompt-size safety
+
+- lifecycle events are coalesced before delivery
+- buffered lifecycle events are capped per thread
+- `toPromptContext()` should show lifecycle events in a compact section
+
+### Runtime safety
+
+- raw pending lifecycle events are buffered before coalescing
+- snapshotting happens before async handlers run
+- events that arrive during handler execution remain buffered for the next cycle
+
+### Product semantics
+
+- Hub still sends structure-rich lifecycle events to participants/admins
+- connectors stop treating those events as standalone chat turns
+- bots still learn about thread state changes on the next meaningful delivery
+
+## Open Tradeoff
+
+`thread_created` remains immediate by default because the SDK already models
+invite-triggered delivery via `triggerOnInvite`, and the guide encourages bots
+to acknowledge new threads promptly. If product direction later changes, this
+can be switched by configuration instead of another structural rewrite.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coco-xyz/hxa-connect-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coco-xyz/hxa-connect-sdk",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coco-xyz/hxa-connect-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "TypeScript SDK for HXA-Connect B2B Protocol — agent-to-agent communication",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 export { HxaConnectClient } from './client.js';
 export type { HxaConnectClientOptions, ReconnectOptions, EventHandler } from './client.js';
 export { ApiError, DownloadError } from './client.js';
-export { ThreadContext } from './thread-context.js';
-export type { ThreadSnapshot, MentionTrigger, ThreadContextOptions } from './thread-context.js';
+export { ThreadContext, formatThreadLifecycleEvent } from './thread-context.js';
+export type {
+  ThreadSnapshot,
+  MentionTrigger,
+  ThreadContextOptions,
+  ThreadLifecycleEvent,
+  ThreadLifecycleEventMode,
+  ThreadLifecycleEventType,
+  ThreadLifecycleOptions,
+} from './thread-context.js';
 export { getProtocolGuide } from './protocol-guide.js';
 export * from './types.js';

--- a/src/thread-context.ts
+++ b/src/thread-context.ts
@@ -33,7 +33,42 @@ function displaySender(msg: WireThreadMessage): string {
   return botName;
 }
 
+function lifecycleThreadId(event: ThreadLifecycleEvent): string {
+  return event.type === 'thread_created' || event.type === 'thread_updated'
+    ? event.thread.id
+    : event.thread_id;
+}
+
+function appendBounded<T>(items: T[], item: T, maxSize: number): T[] {
+  const next = [...items, item];
+  if (next.length > maxSize) {
+    next.splice(0, next.length - maxSize);
+  }
+  return next;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
 // ─── Types ──────────────────────────────────────────────────
+
+export type ThreadLifecycleEventType =
+  | 'thread_created'
+  | 'thread_updated'
+  | 'thread_status_changed'
+  | 'thread_artifact'
+  | 'thread_participant';
+
+export type ThreadLifecycleEvent = Extract<WsServerEvent, { type: ThreadLifecycleEventType }>;
+export type ThreadLifecycleEventMode = 'deliver' | 'buffer' | 'ignore';
+
+export interface ThreadLifecycleOptions {
+  /** Max raw lifecycle events buffered per thread before oldest are dropped (default: 25). */
+  maxBufferSize?: number;
+  /** Per-event mode override. */
+  modes?: Partial<Record<ThreadLifecycleEventType, ThreadLifecycleEventMode>>;
+}
 
 export interface ThreadSnapshot {
   thread: Thread;
@@ -44,12 +79,16 @@ export interface ThreadSnapshot {
   bufferedCount: number;
   /** Latest artifacts (one per key) */
   artifacts: Artifact[];
+  /** Coalesced lifecycle events pending for this delivery. */
+  lifecycleEvents: ThreadLifecycleEvent[];
 }
 
 export interface MentionTrigger {
   threadId: string;
   message: WireThreadMessage;
   snapshot: ThreadSnapshot;
+  /** Why delivery happened. */
+  reason: 'message' | 'invite' | 'lifecycle' | 'flush';
 }
 
 export interface ThreadContextOptions {
@@ -63,9 +102,79 @@ export interface ThreadContextOptions {
   maxBufferSize?: number;
   /** Also trigger on thread_created events where this bot is a participant */
   triggerOnInvite?: boolean;
+  /** Lifecycle event buffering policy. */
+  lifecycle?: ThreadLifecycleOptions;
 }
 
 type MentionHandler = (trigger: MentionTrigger) => void | Promise<void>;
+
+export function formatThreadLifecycleEvent(event: ThreadLifecycleEvent): string {
+  switch (event.type) {
+    case 'thread_created': {
+      const topic = event.thread.topic || 'untitled';
+      const tags = event.thread.tags?.length ? ` (tags: ${event.thread.tags.join(', ')})` : '';
+      return `Thread created: "${topic}"${tags}`;
+    }
+    case 'thread_updated': {
+      const topic = event.thread.topic || 'untitled';
+      const changes = event.changes.length ? event.changes.join(', ') : 'unknown fields';
+      return `Thread updated: "${topic}" (${changes})`;
+    }
+    case 'thread_status_changed': {
+      const by = event.by ? ` by ${event.by}` : '';
+      return `Thread status changed: "${event.topic}" ${event.from} -> ${event.to}${by}`;
+    }
+    case 'thread_artifact': {
+      const artifact = event.artifact;
+      const title = artifact.title || artifact.artifact_key;
+      return `Artifact ${event.action}: "${title}" (type: ${artifact.type})`;
+    }
+    case 'thread_participant': {
+      const name = event.bot_name || event.bot_id;
+      const label = event.label ? ` [${event.label}]` : '';
+      const by = event.by ? ` by ${event.by}` : '';
+      return `${name}${label} ${event.action} the thread${by}`;
+    }
+  }
+}
+
+function coalesceLifecycleEvents(events: ThreadLifecycleEvent[]): ThreadLifecycleEvent[] {
+  let created: Extract<ThreadLifecycleEvent, { type: 'thread_created' }> | undefined;
+  let updated: Extract<ThreadLifecycleEvent, { type: 'thread_updated' }> | undefined;
+  let statusChanged: Extract<ThreadLifecycleEvent, { type: 'thread_status_changed' }> | undefined;
+  const artifactEvents = new Map<string, Extract<ThreadLifecycleEvent, { type: 'thread_artifact' }>>();
+  const participantEvents = new Map<string, Extract<ThreadLifecycleEvent, { type: 'thread_participant' }>>();
+
+  for (const event of events) {
+    switch (event.type) {
+      case 'thread_created':
+        created = event;
+        break;
+      case 'thread_updated':
+        updated = updated
+          ? { ...event, changes: uniqueStrings([...updated.changes, ...event.changes]) }
+          : event;
+        break;
+      case 'thread_status_changed':
+        statusChanged = event;
+        break;
+      case 'thread_artifact':
+        artifactEvents.set(event.artifact.artifact_key, event);
+        break;
+      case 'thread_participant':
+        participantEvents.set(event.bot_id, event);
+        break;
+    }
+  }
+
+  const result: ThreadLifecycleEvent[] = [];
+  if (created) result.push(created);
+  if (updated) result.push(updated);
+  if (statusChanged) result.push(statusChanged);
+  result.push(...participantEvents.values());
+  result.push(...artifactEvents.values());
+  return result;
+}
 
 // ─── ThreadContext ──────────────────────────────────────────
 
@@ -76,10 +185,14 @@ type MentionHandler = (trigger: MentionTrigger) => void | Promise<void>;
  * when the bot is @mentioned, reducing noise and providing full
  * context for LLM processing.
  *
+ * Lifecycle events can also be buffered as silent context. By default:
+ * - `thread_created` delivers immediately when `triggerOnInvite` is enabled
+ * - other thread lifecycle events are buffered and attached to the next delivery
+ *
  * Usage:
  * ```ts
  * const ctx = new ThreadContext(client, { botNames: ['mybot'] });
- * ctx.onMention(async ({ threadId, message, snapshot }) => {
+ * ctx.onMention(async ({ threadId, snapshot }) => {
  *   const prompt = ctx.toPromptContext(threadId);
  *   // Feed to LLM, then reply
  *   await client.sendThreadMessage(threadId, response);
@@ -89,11 +202,16 @@ type MentionHandler = (trigger: MentionTrigger) => void | Promise<void>;
  */
 export class ThreadContext {
   private client: HxaConnectClient;
-  private opts: Required<Omit<ThreadContextOptions, 'triggerPatterns' | 'botId'>> & {
+  private opts: Required<Omit<ThreadContextOptions, 'triggerPatterns' | 'botId' | 'lifecycle'>> & {
     triggerPatterns: RegExp[];
     botId: string | null;
+    lifecycle: {
+      maxBufferSize: number;
+      modes: Record<ThreadLifecycleEventType, ThreadLifecycleEventMode>;
+    };
   };
   private buffers: Map<string, WireThreadMessage[]> = new Map();
+  private lifecycleBuffers: Map<string, ThreadLifecycleEvent[]> = new Map();
   private threadCache: Map<string, Thread> = new Map();
   private participantCache: Map<string, ThreadParticipant[]> = new Map();
   private artifactCache: Map<string, Artifact[]> = new Map();
@@ -106,10 +224,18 @@ export class ThreadContext {
   constructor(client: HxaConnectClient, opts: ThreadContextOptions) {
     this.client = client;
 
-    // Build @mention regex patterns from bot names
     const mentionPatterns = opts.botNames.map(
       name => new RegExp(`@${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i')
     );
+
+    const lifecycleModes: Record<ThreadLifecycleEventType, ThreadLifecycleEventMode> = {
+      thread_created: opts.triggerOnInvite === false ? 'buffer' : 'deliver',
+      thread_updated: 'buffer',
+      thread_status_changed: 'buffer',
+      thread_artifact: 'buffer',
+      thread_participant: 'buffer',
+      ...(opts.lifecycle?.modes ?? {}),
+    };
 
     this.opts = {
       botNames: opts.botNames,
@@ -117,6 +243,10 @@ export class ThreadContext {
       triggerPatterns: [...mentionPatterns, ...(opts.triggerPatterns ?? [])],
       maxBufferSize: opts.maxBufferSize ?? 50,
       triggerOnInvite: opts.triggerOnInvite ?? true,
+      lifecycle: {
+        maxBufferSize: opts.lifecycle?.maxBufferSize ?? 25,
+        modes: lifecycleModes,
+      },
     };
   }
 
@@ -136,18 +266,16 @@ export class ThreadContext {
     if (this.started) return;
     this.started = true;
 
-    // Auto-detect bot ID
     if (!this.opts.botId) {
       try {
         const profile = await this.client.getProfile();
         this.opts.botId = profile.id;
       } catch (err) {
-        this.started = false; // Allow retry
+        this.started = false;
         throw err;
       }
     }
 
-    // Track listeners so stop() can remove them
     const onThreadMessage = (event: WsServerEvent) => {
       if (event.type !== 'thread_message') return;
       this.handleThreadMessage(event.thread_id, event.message);
@@ -155,39 +283,43 @@ export class ThreadContext {
 
     const onThreadCreated = (event: WsServerEvent) => {
       if (event.type !== 'thread_created') return;
-      this.threadCache.set(event.thread.id, event.thread);
-      if (this.opts.triggerOnInvite) {
-        this.triggerDelivery(event.thread.id, null);
-      }
+      this.handleLifecycleEvent(event);
     };
 
     const onThreadUpdated = (event: WsServerEvent) => {
       if (event.type !== 'thread_updated') return;
-      this.threadCache.set(event.thread.id, event.thread);
+      this.handleLifecycleEvent(event);
     };
 
     const onThreadArtifact = (event: WsServerEvent) => {
       if (event.type !== 'thread_artifact') return;
-      const artifacts = this.artifactCache.get(event.thread_id) ?? [];
-      const idx = artifacts.findIndex(a => a.artifact_key === event.artifact.artifact_key);
-      if (idx >= 0) {
-        artifacts[idx] = event.artifact;
-      } else {
-        artifacts.push(event.artifact);
-      }
-      this.artifactCache.set(event.thread_id, artifacts);
+      this.handleLifecycleEvent(event);
+    };
+
+    const onThreadStatusChanged = (event: WsServerEvent) => {
+      if (event.type !== 'thread_status_changed') return;
+      this.handleLifecycleEvent(event);
+    };
+
+    const onThreadParticipant = (event: WsServerEvent) => {
+      if (event.type !== 'thread_participant') return;
+      this.handleLifecycleEvent(event);
     };
 
     this.client.on('thread_message', onThreadMessage);
     this.client.on('thread_created', onThreadCreated);
     this.client.on('thread_updated', onThreadUpdated);
     this.client.on('thread_artifact', onThreadArtifact);
+    this.client.on('thread_status_changed', onThreadStatusChanged);
+    this.client.on('thread_participant', onThreadParticipant);
 
     this.listenerRemovers = [
       () => this.client.off('thread_message', onThreadMessage),
       () => this.client.off('thread_created', onThreadCreated),
       () => this.client.off('thread_updated', onThreadUpdated),
       () => this.client.off('thread_artifact', onThreadArtifact),
+      () => this.client.off('thread_status_changed', onThreadStatusChanged),
+      () => this.client.off('thread_participant', onThreadParticipant),
     ];
   }
 
@@ -203,39 +335,96 @@ export class ThreadContext {
   private handleThreadMessage(threadId: string, message: WireThreadMessage): void {
     if (!this.started) return;
 
-    // Don't buffer our own messages — but allow human-authored messages
-    // sent via Web UI (provenance.authored_by === 'human')
     if (message.sender_id === this.opts.botId) {
       const meta = parseMeta(message.metadata);
       const prov = meta?.provenance as Record<string, unknown> | undefined;
       if (!prov || prov.authored_by !== 'human') return;
     }
 
-    // Buffer the message
     const buffer = this.buffers.get(threadId) ?? [];
     buffer.push(message);
 
-    // Enforce max buffer size (drop oldest)
     if (buffer.length > this.opts.maxBufferSize) {
       buffer.splice(0, buffer.length - this.opts.maxBufferSize);
     }
     this.buffers.set(threadId, buffer);
 
-    // Check if this message triggers delivery
     if (this.isMention(message)) {
-      this.triggerDelivery(threadId, message);
+      void this.triggerDelivery(threadId, message, 'message');
+    }
+  }
+
+  private handleLifecycleEvent(event: ThreadLifecycleEvent): void {
+    if (!this.started) return;
+
+    this.applyLifecycleCaches(event);
+
+    const mode = this.opts.lifecycle.modes[event.type];
+    if (mode === 'ignore') return;
+
+    const threadId = lifecycleThreadId(event);
+    const buffer = this.lifecycleBuffers.get(threadId) ?? [];
+    this.lifecycleBuffers.set(threadId, appendBounded(buffer, event, this.opts.lifecycle.maxBufferSize));
+
+    if (mode === 'deliver') {
+      const reason = event.type === 'thread_created' ? 'invite' : 'lifecycle';
+      void this.triggerDelivery(threadId, null, reason);
+    }
+  }
+
+  private applyLifecycleCaches(event: ThreadLifecycleEvent): void {
+    switch (event.type) {
+      case 'thread_created':
+      case 'thread_updated':
+        this.threadCache.set(event.thread.id, event.thread);
+        break;
+      case 'thread_status_changed': {
+        const prev = this.threadCache.get(event.thread_id);
+        if (prev) {
+          this.threadCache.set(event.thread_id, { ...prev, status: event.to, topic: event.topic });
+        }
+        break;
+      }
+      case 'thread_artifact': {
+        const artifacts = [...(this.artifactCache.get(event.thread_id) ?? [])];
+        const idx = artifacts.findIndex(a => a.artifact_key === event.artifact.artifact_key);
+        if (idx >= 0) {
+          artifacts[idx] = event.artifact;
+        } else {
+          artifacts.push(event.artifact);
+        }
+        this.artifactCache.set(event.thread_id, artifacts);
+        break;
+      }
+      case 'thread_participant': {
+        const participants = this.participantCache.get(event.thread_id);
+        if (!participants) break;
+        if (event.action === 'joined') {
+          if (!participants.some(p => p.bot_id === event.bot_id)) {
+            participants.push({
+              thread_id: event.thread_id,
+              bot_id: event.bot_id,
+              name: event.bot_name,
+              label: event.label ?? null,
+              joined_at: Date.now(),
+            });
+          }
+        } else {
+          const idx = participants.findIndex(p => p.bot_id === event.bot_id);
+          if (idx >= 0) participants.splice(idx, 1);
+        }
+        this.participantCache.set(event.thread_id, participants);
+        break;
+      }
     }
   }
 
   private isMention(message: WireThreadMessage): boolean {
-    // mention_all (@all / @所有人) triggers delivery for all bots
     if (message.mention_all) return true;
-    // Check mentions array (includes server-injected implicit mentions, e.g. reply_to)
     if (this.opts.botId && message.mentions?.some(m => m.bot_id === this.opts.botId)) return true;
-    // Check text content of all parts
     const textContent = this.extractText(message);
     return this.opts.triggerPatterns.some(pattern => {
-      pattern.lastIndex = 0; // Reset stateful regex (g/y flags)
+      pattern.lastIndex = 0;
       return pattern.test(textContent);
     });
   }
@@ -252,15 +441,20 @@ export class ThreadContext {
     return parts.join(' ');
   }
 
-  private async triggerDelivery(threadId: string, triggerMessage: WireThreadMessage | null): Promise<void> {
+  private async triggerDelivery(
+    threadId: string,
+    triggerMessage: WireThreadMessage | null,
+    reason: MentionTrigger['reason'],
+  ): Promise<void> {
     const buffer = this.buffers.get(threadId) ?? [];
     const bufferedCount = buffer.length;
-
-    // Snapshot messages NOW before any async work — prevents messages arriving
-    // during await from being included in snapshot AND kept in buffer (duplicates).
     const snapshotMessages = buffer.slice(0, bufferedCount);
 
-    // Build snapshot — fetch thread if not cached
+    const lifecycleBuffer = this.lifecycleBuffers.get(threadId) ?? [];
+    const lifecycleCount = lifecycleBuffer.length;
+    const snapshotLifecycleRaw = lifecycleBuffer.slice(0, lifecycleCount);
+    const snapshotLifecycleEvents = coalesceLifecycleEvents(snapshotLifecycleRaw);
+
     let thread = this.threadCache.get(threadId);
     let participants = this.participantCache.get(threadId);
     if (!thread || !participants) {
@@ -271,7 +465,6 @@ export class ThreadContext {
         this.threadCache.set(threadId, full);
         this.participantCache.set(threadId, full.participants);
       } catch {
-        // If we can't fetch, use what we have
         thread = thread ?? { id: threadId, topic: 'unknown' } as Thread;
         participants = participants ?? [];
       }
@@ -285,16 +478,25 @@ export class ThreadContext {
       newMessages: snapshotMessages,
       bufferedCount,
       artifacts,
+      lifecycleEvents: snapshotLifecycleEvents,
     };
 
-    // If no trigger message (e.g. thread invite), create a synthetic one
     const trigger: MentionTrigger = {
       threadId,
-      message: triggerMessage ?? snapshotMessages[snapshotMessages.length - 1] ?? { id: '', thread_id: threadId, sender_id: null, content: '', content_type: 'text', parts: [], metadata: null, created_at: Date.now() },
+      message: triggerMessage ?? snapshotMessages[snapshotMessages.length - 1] ?? {
+        id: '',
+        thread_id: threadId,
+        sender_id: null,
+        content: '',
+        content_type: 'text',
+        parts: [],
+        metadata: null,
+        created_at: Date.now(),
+      },
       snapshot,
+      reason,
     };
 
-    // Call handlers BEFORE clearing buffer so toPromptContext() has data
     for (const handler of this.handlers) {
       try {
         await handler(trigger);
@@ -303,22 +505,24 @@ export class ThreadContext {
       }
     }
 
-    // Preserve messages that arrived during async handler execution.
     const currentBuffer = this.buffers.get(threadId) ?? [];
     const newlyArrived = currentBuffer.slice(bufferedCount);
     this.buffers.set(threadId, newlyArrived);
 
-    // Use the last delivered message's created_at for delta watermark,
-    // avoiding client/server clock skew issues with Date.now().
-    const lastMsg = snapshotMessages[snapshotMessages.length - 1];
-    const watermark = lastMsg?.created_at ?? Date.now();
-    this.deliveredUpTo.set(threadId, watermark);
-    // Track IDs at the watermark timestamp for dedup (same-timestamp messages)
-    const idsAtWatermark = new Set<string>();
-    for (const m of snapshotMessages) {
-      if (m.created_at === watermark) idsAtWatermark.add(m.id);
+    const currentLifecycleBuffer = this.lifecycleBuffers.get(threadId) ?? [];
+    const newlyArrivedLifecycle = currentLifecycleBuffer.slice(lifecycleCount);
+    this.lifecycleBuffers.set(threadId, newlyArrivedLifecycle);
+
+    if (snapshotMessages.length > 0) {
+      const lastMsg = snapshotMessages[snapshotMessages.length - 1];
+      const watermark = lastMsg.created_at;
+      this.deliveredUpTo.set(threadId, watermark);
+      const idsAtWatermark = new Set<string>();
+      for (const m of snapshotMessages) {
+        if (m.created_at === watermark) idsAtWatermark.add(m.id);
+      }
+      this.deliveredIds.set(threadId, idsAtWatermark);
     }
-    this.deliveredIds.set(threadId, idsAtWatermark);
   }
 
   /**
@@ -329,12 +533,24 @@ export class ThreadContext {
   }
 
   /**
-   * Get all thread IDs with buffered messages.
+   * Get the number of pending lifecycle events for a thread.
+   */
+  getLifecycleBufferSize(threadId: string): number {
+    return this.lifecycleBuffers.get(threadId)?.length ?? 0;
+  }
+
+  /**
+   * Get all thread IDs with buffered messages or lifecycle events.
    */
   getActiveThreads(): string[] {
-    return [...this.buffers.entries()]
-      .filter(([, buf]) => buf.length > 0)
-      .map(([id]) => id);
+    const ids = new Set<string>();
+    for (const [id, buf] of this.buffers.entries()) {
+      if (buf.length > 0) ids.add(id);
+    }
+    for (const [id, buf] of this.lifecycleBuffers.entries()) {
+      if (buf.length > 0) ids.add(id);
+    }
+    return [...ids];
   }
 
   /**
@@ -342,8 +558,9 @@ export class ThreadContext {
    */
   async flush(threadId: string): Promise<void> {
     const buffer = this.buffers.get(threadId) ?? [];
-    if (buffer.length > 0) {
-      await this.triggerDelivery(threadId, buffer[buffer.length - 1]);
+    const lifecycle = this.lifecycleBuffers.get(threadId) ?? [];
+    if (buffer.length > 0 || lifecycle.length > 0) {
+      await this.triggerDelivery(threadId, buffer[buffer.length - 1] ?? null, 'flush');
     }
   }
 
@@ -353,7 +570,7 @@ export class ThreadContext {
    * Generate LLM-ready prompt context for a thread.
    *
    * Modes:
-   * - `summary`: Thread metadata + participant list + message count (cheap)
+   * - `summary`: Thread metadata + participant list + pending counts
    * - `full`: Summary + all buffered messages as conversation (default)
    * - `delta`: Only new messages since last delivery
    */
@@ -365,10 +582,10 @@ export class ThreadContext {
     const participants = this.participantCache.get(threadId) ?? [];
     const buffer = this.buffers.get(threadId) ?? [];
     const artifacts = this.artifactCache.get(threadId) ?? [];
+    const lifecycleEvents = coalesceLifecycleEvents(this.lifecycleBuffers.get(threadId) ?? []);
 
     const lines: string[] = [];
 
-    // Thread header
     if (thread) {
       lines.push(`## Thread: ${thread.topic}`);
       lines.push(`Status: ${thread.status} | ID: ${thread.id}`);
@@ -378,7 +595,6 @@ export class ThreadContext {
       lines.push(`## Thread: ${threadId}`);
     }
 
-    // Participants
     if (participants.length > 0) {
       const names = participants.map(p => {
         const label = p.label ? ` (${p.label})` : '';
@@ -387,7 +603,6 @@ export class ThreadContext {
       lines.push(`Participants: ${names.join(', ')}`);
     }
 
-    // Artifacts summary
     if (artifacts.length > 0) {
       lines.push('');
       lines.push('### Artifacts');
@@ -396,13 +611,20 @@ export class ThreadContext {
       }
     }
 
+    if (lifecycleEvents.length > 0) {
+      lines.push('');
+      lines.push('### Lifecycle Events');
+      for (const event of lifecycleEvents) {
+        lines.push(`- ${formatThreadLifecycleEvent(event)}`);
+      }
+    }
+
     if (mode === 'summary') {
       lines.push('');
-      lines.push(`[${buffer.length} new message(s) buffered]`);
+      lines.push(`[${buffer.length} new message(s), ${lifecycleEvents.length} lifecycle event(s) buffered]`);
       return lines.join('\n');
     }
 
-    // Messages
     const messages = mode === 'delta'
       ? buffer.filter(m => {
           const watermark = this.deliveredUpTo.get(threadId) ?? 0;

--- a/test/thread-context.test.ts
+++ b/test/thread-context.test.ts
@@ -1,0 +1,276 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ThreadContext,
+  formatThreadLifecycleEvent,
+  type ThreadLifecycleEvent,
+} from '../src/index.js';
+
+class FakeClient {
+  private handlers = new Map<string, Set<(event: any) => void>>();
+  private readonly thread: any;
+
+  constructor(thread: any) {
+    this.thread = thread;
+  }
+
+  async getProfile() {
+    return { id: 'bot-1', name: 'mybot' };
+  }
+
+  async getThread(threadId: string) {
+    return { ...this.thread, id: threadId };
+  }
+
+  on(event: string, handler: (event: any) => void) {
+    if (!this.handlers.has(event)) this.handlers.set(event, new Set());
+    this.handlers.get(event)!.add(handler);
+  }
+
+  off(event: string, handler: (event: any) => void) {
+    this.handlers.get(event)?.delete(handler);
+  }
+
+  emit(event: string, payload: any) {
+    for (const handler of this.handlers.get(event) ?? []) handler(payload);
+  }
+
+  emitError(err: unknown) {
+    throw err;
+  }
+}
+
+function makeThread(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'thread-1',
+    org_id: 'org-1',
+    topic: 'Test Thread',
+    tags: ['collab'],
+    status: 'active',
+    initiator_id: 'bot-1',
+    channel_id: null,
+    context: null,
+    close_reason: null,
+    permission_policy: null,
+    revision: 1,
+    created_at: 1000,
+    updated_at: 1000,
+    last_activity_at: 1000,
+    resolved_at: null,
+    participants: [{
+      thread_id: 'thread-1',
+      bot_id: 'bot-1',
+      name: 'mybot',
+      label: null,
+      joined_at: 1000,
+    }],
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'msg-1',
+    thread_id: 'thread-1',
+    sender_id: 'other-bot',
+    sender_name: 'other-bot',
+    content: overrides.content ?? 'hello @mybot',
+    content_type: 'text',
+    parts: [{ type: 'text', content: overrides.content ?? 'hello @mybot' }],
+    mentions: [],
+    mention_all: false,
+    metadata: null,
+    created_at: 2000,
+    ...overrides,
+  };
+}
+
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('ThreadContext lifecycle buffering', () => {
+  it('preserves invite delivery while exposing thread_created as lifecycle context', async () => {
+    const client = new FakeClient(makeThread());
+    const ctx = new ThreadContext(client as any, { botNames: ['mybot'] });
+    const seen: any[] = [];
+    ctx.onMention((trigger) => { seen.push(trigger); });
+
+    await ctx.start();
+    client.emit('thread_created', {
+      type: 'thread_created',
+      thread: makeThread(),
+    });
+    await nextTick();
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].reason, 'invite');
+    assert.equal(seen[0].snapshot.newMessages.length, 0);
+    assert.deepEqual(seen[0].snapshot.lifecycleEvents.map((e: ThreadLifecycleEvent) => e.type), ['thread_created']);
+    assert.equal(
+      formatThreadLifecycleEvent(seen[0].snapshot.lifecycleEvents[0]),
+      'Thread created: "Test Thread" (tags: collab)',
+    );
+  });
+
+  it('buffers thread lifecycle events silently until the next thread message delivery', async () => {
+    const client = new FakeClient(makeThread());
+    const ctx = new ThreadContext(client as any, {
+      botNames: ['mybot'],
+      lifecycle: { maxBufferSize: 10 },
+    });
+    const seen: any[] = [];
+    ctx.onMention((trigger) => { seen.push(trigger); });
+
+    await ctx.start();
+
+    client.emit('thread_updated', {
+      type: 'thread_updated',
+      thread: makeThread({ topic: 'Updated Topic', updated_at: 1100 }),
+      changes: ['topic'],
+    });
+    client.emit('thread_updated', {
+      type: 'thread_updated',
+      thread: makeThread({ topic: 'Updated Topic', context: 'ctx', updated_at: 1200 }),
+      changes: ['context'],
+    });
+    client.emit('thread_status_changed', {
+      type: 'thread_status_changed',
+      thread_id: 'thread-1',
+      topic: 'Updated Topic',
+      from: 'active',
+      to: 'reviewing',
+      by: 'bot-2',
+    });
+    client.emit('thread_artifact', {
+      type: 'thread_artifact',
+      thread_id: 'thread-1',
+      action: 'added',
+      artifact: { artifact_key: 'spec', title: 'Spec', type: 'markdown', version: 1 },
+    });
+    client.emit('thread_artifact', {
+      type: 'thread_artifact',
+      thread_id: 'thread-1',
+      action: 'updated',
+      artifact: { artifact_key: 'spec', title: 'Spec v2', type: 'markdown', version: 2 },
+    });
+    client.emit('thread_participant', {
+      type: 'thread_participant',
+      thread_id: 'thread-1',
+      bot_id: 'bot-3',
+      bot_name: 'helper',
+      action: 'joined',
+      by: 'org:org-1',
+      label: 'reviewer',
+    });
+    client.emit('thread_participant', {
+      type: 'thread_participant',
+      thread_id: 'thread-1',
+      bot_id: 'bot-3',
+      bot_name: 'helper',
+      action: 'left',
+      by: 'org:org-1',
+      label: 'reviewer',
+    });
+
+    client.emit('thread_message', {
+      type: 'thread_message',
+      thread_id: 'thread-1',
+      message: makeMessage(),
+    });
+    await nextTick();
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].reason, 'message');
+    assert.deepEqual(
+      seen[0].snapshot.lifecycleEvents.map((e: ThreadLifecycleEvent) => e.type),
+      ['thread_updated', 'thread_status_changed', 'thread_participant', 'thread_artifact'],
+    );
+    assert.equal(seen[0].snapshot.lifecycleEvents[0].changes.join(','), 'topic,context');
+    assert.equal(seen[0].snapshot.lifecycleEvents[2].action, 'left');
+    assert.equal(seen[0].snapshot.lifecycleEvents[3].action, 'updated');
+    assert.equal(ctx.getLifecycleBufferSize('thread-1'), 0);
+  });
+
+  it('supports lifecycle-only flush and marks those threads as active', async () => {
+    const client = new FakeClient(makeThread());
+    const ctx = new ThreadContext(client as any, { botNames: ['mybot'] });
+    const seen: any[] = [];
+    ctx.onMention((trigger) => { seen.push(trigger); });
+
+    await ctx.start();
+    client.emit('thread_participant', {
+      type: 'thread_participant',
+      thread_id: 'thread-1',
+      bot_id: 'bot-9',
+      bot_name: 'observer',
+      action: 'joined',
+      by: 'bot-2',
+      label: null,
+    });
+
+    assert.deepEqual(ctx.getActiveThreads(), ['thread-1']);
+    assert.match(ctx.toPromptContext('thread-1', 'summary'), /1 lifecycle event\(s\) buffered/);
+
+    await ctx.flush('thread-1');
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].reason, 'flush');
+    assert.equal(seen[0].snapshot.newMessages.length, 0);
+    assert.equal(seen[0].snapshot.lifecycleEvents.length, 1);
+    assert.deepEqual(ctx.getActiveThreads(), []);
+  });
+
+  it('buffers thread_created instead of delivering when triggerOnInvite is disabled', async () => {
+    const client = new FakeClient(makeThread());
+    const ctx = new ThreadContext(client as any, {
+      botNames: ['mybot'],
+      triggerOnInvite: false,
+    });
+    const seen: any[] = [];
+    ctx.onMention((trigger) => { seen.push(trigger); });
+
+    await ctx.start();
+    client.emit('thread_created', {
+      type: 'thread_created',
+      thread: makeThread({ topic: 'Quiet Invite' }),
+    });
+    await nextTick();
+
+    assert.equal(seen.length, 0);
+    assert.equal(ctx.getLifecycleBufferSize('thread-1'), 1);
+
+    await ctx.flush('thread-1');
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].reason, 'flush');
+    assert.equal(seen[0].snapshot.lifecycleEvents[0].thread.topic, 'Quiet Invite');
+  });
+
+  it('does not advance message delta watermark on lifecycle-only delivery', async () => {
+    const client = new FakeClient(makeThread());
+    const ctx = new ThreadContext(client as any, { botNames: ['mybot'] });
+    ctx.onMention(() => {});
+
+    await ctx.start();
+    client.emit('thread_participant', {
+      type: 'thread_participant',
+      thread_id: 'thread-1',
+      bot_id: 'bot-7',
+      bot_name: 'reviewer',
+      action: 'joined',
+      by: 'bot-2',
+      label: null,
+    });
+
+    await ctx.flush('thread-1');
+
+    client.emit('thread_message', {
+      type: 'thread_message',
+      thread_id: 'thread-1',
+      message: makeMessage({ id: 'msg-2', content: 'plain message without mention', created_at: 1500 }),
+    });
+
+    assert.match(ctx.toPromptContext('thread-1', 'delta'), /plain message without mention/);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `ThreadContext` with buffered thread lifecycle event handling
- expose `snapshot.lifecycleEvents`, delivery reasons, and `formatThreadLifecycleEvent()` for connector composition
- add a design doc and ThreadContext tests covering silent buffering, invite delivery, flush, and watermark safety

## Verification
- npm test
- npm run typecheck