### PR TITLE
ci: add automated npm publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — triggered on `v*` tag push, runs `npm ci → build → publish --provenance`
- Uses `NPM_TOKEN` from GitHub Secrets (Automation-type token from the ops-coco npmjs account)
- Matches existing CI workflow style (Node 22, npm cache, timeout, named steps)

## Setup required
1. Create an **Automation** access token on npmjs.com under the `ops-coco` account
2. Add it as `NPM_TOKEN` in either the `openmaxai` org secrets or this repo's secrets (Settings → Secrets → Actions)

## Usage
After merging a version bump commit:
```bash
gh release create v1.2.3 --target main
```
The workflow automatically builds and publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)