### PR TITLE
chore: bump version to 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.1] - 2026-07-17
+
+### Added
+- **Automated npm publish** — GitHub Actions release workflow (`release.yml`): tag push `v*` triggers `npm ci → build → publish --provenance`
+
 ## [1.6.0] - 2026-03-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coco-xyz/hxa-connect-sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coco-xyz/hxa-connect-sdk",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coco-xyz/hxa-connect-sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "TypeScript SDK for HXA-Connect B2B Protocol — agent-to-agent communication",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump to test the automated npm publish workflow.

- `package.json` → 1.6.1
- `package-lock.json` synced
- `CHANGELOG.md` entry added (release workflow addition)

After merge: `gh release create v1.6.1 --target main` to trigger the publish workflow.