### PR TITLE
fix: update repository URL to openmaxai org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.6.2] - 2026-07-17
+
+### Fixed
+- **Repository URL** — `package.json` repository/homepage URLs updated from `coco-xyz` to `openmaxai` to match the actual repo location and fix npm provenance verification
+
 ## [1.6.1] - 2026-07-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coco-xyz/hxa-connect-sdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coco-xyz/hxa-connect-sdk",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coco-xyz/hxa-connect-sdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "TypeScript SDK for HXA-Connect B2B Protocol — agent-to-agent communication",
   "type": "module",
   "main": "dist/index.js",
@@ -36,9 +36,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/coco-xyz/hxa-connect-sdk.git"
+    "url": "https://github.com/openmaxai/hxa-connect-sdk.git"
   },
-  "homepage": "https://github.com/coco-xyz/hxa-connect-sdk",
+  "homepage": "https://github.com/openmaxai/hxa-connect-sdk",
   "hxa-connect": {
     "server": ">=1.4.0"
   },


### PR DESCRIPTION
Fix npm provenance verification failure: `package.json` repository URL and homepage updated from `coco-xyz/hxa-connect-sdk` to `openmaxai/hxa-connect-sdk`.

Bumped to 1.6.2 (1.6.1 tag exists but never published successfully).

After merge: `gh release create v1.6.2 --target main` to verify the full auto-publish flow.